### PR TITLE
docs: Clarify the user's path through the docs

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -6,12 +6,12 @@ use predicates;
 
 use errors::output_fmt;
 
-/// Extend `process::Output` with assertions.
+/// Assert the state of an `Output`.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use assert_cmd::*;
+/// use assert_cmd::prelude::*;
 ///
 /// use std::process::Command;
 ///
@@ -22,6 +22,19 @@ use errors::output_fmt;
 /// ```
 pub trait OutputAssertExt {
     /// Wrap with an interface for that provides assertions on the `process::Output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use assert_cmd::prelude::*;
+    ///
+    /// use std::process::Command;
+    ///
+    /// Command::main_binary()
+    ///     .unwrap()
+    ///     .assert()
+    ///     .success();
+    /// ```
     fn assert(self) -> Assert;
 }
 
@@ -38,7 +51,22 @@ impl<'c> OutputAssertExt for &'c mut process::Command {
     }
 }
 
-/// `process::Output` assertions.
+/// Assert the state of an `Output`.
+///
+/// Create an `Assert` through the `OutputAssertExt` trait.
+///
+/// # Examples
+///
+/// ```rust
+/// use assert_cmd::prelude::*;
+///
+/// use std::process::Command;
+///
+/// Command::main_binary()
+///     .unwrap()
+///     .assert()
+///     .success();
+/// ```
 #[derive(Debug)]
 pub struct Assert {
     output: process::Output,
@@ -47,7 +75,7 @@ pub struct Assert {
 }
 
 impl Assert {
-    /// Convert `std::process::Output` into a `Fail`.
+    /// Create an `Assert` for a given `Output`.
     pub fn new(output: process::Output) -> Self {
         Self {
             output,
@@ -87,7 +115,7 @@ impl Assert {
     /// # Examples
     ///
     /// ```rust
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
@@ -108,7 +136,7 @@ impl Assert {
     /// # Examples
     ///
     /// ```rust
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
@@ -138,7 +166,7 @@ impl Assert {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
@@ -178,7 +206,7 @@ impl Assert {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
@@ -204,7 +232,7 @@ impl Assert {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
@@ -242,7 +270,27 @@ impl fmt::Display for Assert {
     }
 }
 
-/// Convert to a predicate for testing a program's exit code.
+/// Used by `Assert::code` to convert `Self` into the needed `Predicate<i32>`.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use assert_cmd::prelude::*;
+///
+/// use std::process::Command;
+///
+/// Command::main_binary()
+///     .unwrap()
+///     .env("exit", "42")
+///     .assert()
+///     .code(42);
+/// // which is equivalent to
+/// Command::main_binary()
+///     .unwrap()
+///     .env("exit", "42")
+///     .assert()
+///     .code(predicates::ord::eq(42));
+/// ```
 pub trait IntoCodePredicate<P>
 where
     P: predicates::Predicate<i32>,

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,3 +1,17 @@
+//! Simplify running `bin`s in a Cargo project.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use assert_cmd::prelude::*;
+//!
+//! use std::process::Command;
+//!
+//! Command::main_binary()
+//!     .unwrap()
+//!     .unwrap();
+//! ```
+
 use std::ffi;
 use std::path;
 use std::process;
@@ -5,12 +19,14 @@ use std::process;
 use escargot;
 use failure;
 
-/// Extend `Command` with helpers for running the current crate's binaries.
+/// Create a `Command` for a `bin` in the Cargo project.
 pub trait CommandCargoExt
 where
     Self: Sized,
 {
     /// Create a `Command` to run the crate's main binary.
+    ///
+    /// Note: only works if there one bin in the crate.
     ///
     /// # Examples
     ///
@@ -57,21 +73,16 @@ where
 }
 
 impl CommandCargoExt for process::Command {
-    /// Run the crate's main binary.
-    ///
-    /// Note: only works if there one bin in the crate.
     fn main_binary() -> Result<Self, failure::Error> {
         let cmd = main_binary_path()?;
         Ok(process::Command::new(&cmd))
     }
 
-    /// Run a specific binary of the current crate.
     fn cargo_bin<S: AsRef<ffi::OsStr>>(name: S) -> Result<Self, failure::Error> {
         let cmd = cargo_bin_path(name)?;
         Ok(process::Command::new(&cmd))
     }
 
-    /// Run a specific example of the current crate.
     fn cargo_example<S: AsRef<ffi::OsStr>>(name: S) -> Result<Self, failure::Error> {
         let cmd = cargo_example_path(name)?;
         Ok(process::Command::new(&cmd))

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -4,7 +4,20 @@ use std::str;
 use errors::OutputError;
 use errors::OutputResult;
 
-/// Extends `std::process::Output` with methods to convert it to an `OutputResult`.
+/// Convert an `Output` to a `OutputResult`.
+///
+/// # Examples
+///
+/// ```rust
+/// use assert_cmd::prelude::*;
+///
+/// use std::process::Command;
+///
+/// let result = Command::new("echo")
+///     .args(&["42"])
+///     .ok();
+/// assert!(result.is_ok());
+/// ```
 pub trait OutputOkExt
 where
     Self: ::std::marker::Sized,
@@ -14,14 +27,14 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
-    /// Command::new("echo")
+    /// let result = Command::new("echo")
     ///     .args(&["42"])
-    ///     .ok()
-    ///     .unwrap();
+    ///     .ok();
+    /// assert!(result.is_ok());
     /// ```
     fn ok(self) -> OutputResult;
 
@@ -30,11 +43,11 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
-    /// Command::new("echo")
+    /// let output = Command::new("echo")
     ///     .args(&["42"])
     ///     .unwrap();
     /// ```
@@ -50,12 +63,13 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
-    /// Command::new("non_existent_command")
-    ///     .args(&["42"])
+    /// let err = Command::main_binary()
+    ///     .unwrap()
+    ///     .env("exit", "42")
     ///     .unwrap_err();
     /// ```
     fn unwrap_err(self) -> OutputError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,9 +5,35 @@ use std::str;
 use failure;
 
 /// `std::process::Output` represented as a `Result`.
+///
+/// # Examples
+///
+/// ```rust
+/// use assert_cmd::prelude::*;
+///
+/// use std::process::Command;
+///
+/// let result = Command::new("echo")
+///     .args(&["42"])
+///     .ok();
+/// assert!(result.is_ok());
+/// ```
 pub type OutputResult = Result<process::Output, OutputError>;
 
-/// `std::process::Output` as a `Fail`.
+/// `Command` error.
+///
+/// # Examples
+///
+/// ```rust
+/// use assert_cmd::prelude::*;
+///
+/// use std::process::Command;
+///
+/// let err = Command::main_binary()
+///     .unwrap()
+///     .env("exit", "42")
+///     .unwrap_err();
+/// ```
 #[derive(Fail, Debug)]
 pub struct OutputError {
     cmd: Option<String>,
@@ -43,13 +69,30 @@ impl OutputError {
         self
     }
 
-    /// Add the `stdn` for additional context.
+    /// Add the `stdin` for additional context.
     pub fn set_stdin(mut self, stdin: Vec<u8>) -> Self {
         self.stdin = Some(stdin);
         self
     }
 
     /// Access the contained `std::process::Output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use assert_cmd::prelude::*;
+    ///
+    /// use std::process::Command;
+    ///
+    /// let err = Command::main_binary()
+    ///     .unwrap()
+    ///     .env("exit", "42")
+    ///     .unwrap_err();
+    /// let output = err
+    ///     .as_output()
+    ///     .unwrap();
+    /// assert_eq!(Some(42), output.status.code());
+    /// ```
     pub fn as_output(&self) -> Option<&process::Output> {
         match self.cause {
             OutputCause::Expected(ref e) => Some(&e.output),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,7 @@ extern crate serde;
 
 mod assert;
 pub use assert::*;
-mod cargo;
-pub use cargo::*;
+pub mod cargo;
 mod cmd;
 pub use cmd::*;
 mod stdin;

--- a/src/stdin.rs
+++ b/src/stdin.rs
@@ -9,14 +9,14 @@ use cmd::dump_buffer;
 use errors::OutputError;
 use errors::OutputResult;
 
-/// Extend `Command` with a helper to pass a buffer to `stdin`
+/// Write to `stdin` of a `Command`.
 pub trait CommandStdInExt {
     /// Write `buffer` to `stdin` when the command is run.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use assert_cmd::*;
+    /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
     ///
@@ -41,7 +41,21 @@ impl CommandStdInExt for process::Command {
     }
 }
 
-/// `std::process::Command` with a `stdin` buffer.
+/// `Command` that carries the `stdin` buffer.
+///
+/// Create a `StdInCommand` through the `CommandStdInExt` trait.
+///
+/// # Examples
+///
+/// ```rust
+/// use assert_cmd::prelude::*;
+///
+/// use std::process::Command;
+///
+/// Command::new("cat")
+///     .with_stdin("42")
+///     .unwrap();
+/// ```
 #[derive(Debug)]
 pub struct StdInCommand {
     cmd: process::Command,


### PR DESCRIPTION
Fixes #12

BREAKING CHANGE: This included moving all `cargo` stuff under a `cargo`
module in the public API.  The intent was to not add noise to the main
API with more tangential parts.  This might hide the extension trait too
much.  It might be added back to the root if this was found to confuse
people.