### PR TITLE
feat(assert): Short-hand output predicates

### DIFF
--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -10,52 +10,40 @@ use predicates::prelude::*;
 fn main_binary() {
     let mut cmd = process::Command::main_binary().unwrap();
     cmd.env("stdout", "42");
-    cmd.assert()
-        .success()
-        .stdout(&predicate::eq("42").trim().from_utf8());
+    cmd.assert().success().stdout(predicate::eq("42").trim());
 }
 
 #[test]
 fn main_binary_with_empty_env() {
     let mut cmd = process::Command::main_binary().unwrap();
     cmd.env_clear().env("stdout", "42");
-    cmd.assert()
-        .success()
-        .stdout(&predicate::eq("42").trim().from_utf8());
+    cmd.assert().success().stdout(predicate::eq("42").trim());
 }
 
 #[test]
 fn cargo_binary() {
     let mut cmd = process::Command::cargo_bin("bin_fixture").unwrap();
     cmd.env("stdout", "42");
-    cmd.assert()
-        .success()
-        .stdout(&predicate::eq("42").trim().from_utf8());
+    cmd.assert().success().stdout(predicate::eq("42").trim());
 }
 
 #[test]
 fn cargo_binary_with_empty_env() {
     let mut cmd = process::Command::cargo_bin("bin_fixture").unwrap();
     cmd.env_clear().env("stdout", "42");
-    cmd.assert()
-        .success()
-        .stdout(&predicate::eq("42").trim().from_utf8());
+    cmd.assert().success().stdout(predicate::eq("42").trim());
 }
 
 #[test]
 fn cargo_example() {
     let mut cmd = process::Command::cargo_example("example_fixture").unwrap();
     cmd.env("stdout", "42");
-    cmd.assert()
-        .success()
-        .stdout(&predicate::eq("42").trim().from_utf8());
+    cmd.assert().success().stdout(predicate::eq("42").trim());
 }
 
 #[test]
 fn cargo_example_with_empty_env() {
     let mut cmd = process::Command::cargo_example("example_fixture").unwrap();
     cmd.env_clear().env("stdout", "42");
-    cmd.assert()
-        .success()
-        .stdout(&predicate::eq("42").trim().from_utf8());
+    cmd.assert().success().stdout(predicate::eq("42").trim());
 }


### PR DESCRIPTION
Fixes #2

BREAKING CHANGE: `stdout` / `stderr` now take a predicate by ownership.