### PR TITLE
fix(assert): Don't put concrete predicates in the API

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -154,7 +154,7 @@ impl Assert {
         self
     }
 
-    /// Ensure the command returned the expected code.
+    /// Ensure the command aborted before returning a code.
     pub fn interrupted(self) -> Self {
         if self.output.status.code().is_some() {
             panic!("Unexpected completion\n{}", self);
@@ -166,7 +166,7 @@ impl Assert {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
@@ -176,12 +176,6 @@ impl Assert {
     ///     .env("exit", "42")
     ///     .assert()
     ///     .code(42);
-    /// // which is equivalent to
-    /// Command::main_binary()
-    ///     .unwrap()
-    ///     .env("exit", "42")
-    ///     .assert()
-    ///     .code(predicates::ord::eq(42));
     /// ```
     pub fn code<I, P>(self, pred: I) -> Self
     where
@@ -206,7 +200,7 @@ impl Assert {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
@@ -216,7 +210,7 @@ impl Assert {
     ///     .env("stdout", "hello")
     ///     .env("stderr", "world")
     ///     .assert()
-    ///     .stdout(predicates::ord::eq(b"hello"));
+    ///     .stdout("hello\n");
     /// ```
     pub fn stdout<I, P>(self, pred: I) -> Self
     where
@@ -240,7 +234,7 @@ impl Assert {
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use assert_cmd::prelude::*;
     ///
     /// use std::process::Command;
@@ -250,7 +244,7 @@ impl Assert {
     ///     .env("stdout", "hello")
     ///     .env("stderr", "world")
     ///     .assert()
-    ///     .stderr(predicates::ord::eq(b"world"));
+    ///     .stderr("world\n");
     /// ```
     pub fn stderr<I, P>(self, pred: I) -> Self
     where
@@ -349,11 +343,12 @@ where
     }
 }
 
-impl<P> IntoOutputPredicate<predicates::str::Utf8Predicate<P>> for P
-where
-    P: predicates::Predicate<str>,
+impl IntoOutputPredicate<predicates::str::Utf8Predicate<predicates::ord::EqPredicate<&'static str>>>
+    for &'static str
 {
-    fn into_output(self) -> predicates::str::Utf8Predicate<P> {
-        self.from_utf8()
+    fn into_output(
+        self,
+    ) -> predicates::str::Utf8Predicate<predicates::ord::EqPredicate<&'static str>> {
+        predicates::ord::eq(self).from_utf8()
     }
 }

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -4,46 +4,45 @@ extern crate predicates;
 use std::process;
 
 use assert_cmd::prelude::*;
-use predicates::prelude::*;
 
 #[test]
 fn main_binary() {
     let mut cmd = process::Command::main_binary().unwrap();
     cmd.env("stdout", "42");
-    cmd.assert().success().stdout(predicate::eq("42").trim());
+    cmd.assert().success().stdout("42\n");
 }
 
 #[test]
 fn main_binary_with_empty_env() {
     let mut cmd = process::Command::main_binary().unwrap();
     cmd.env_clear().env("stdout", "42");
-    cmd.assert().success().stdout(predicate::eq("42").trim());
+    cmd.assert().success().stdout("42\n");
 }
 
 #[test]
 fn cargo_binary() {
     let mut cmd = process::Command::cargo_bin("bin_fixture").unwrap();
     cmd.env("stdout", "42");
-    cmd.assert().success().stdout(predicate::eq("42").trim());
+    cmd.assert().success().stdout("42\n");
 }
 
 #[test]
 fn cargo_binary_with_empty_env() {
     let mut cmd = process::Command::cargo_bin("bin_fixture").unwrap();
     cmd.env_clear().env("stdout", "42");
-    cmd.assert().success().stdout(predicate::eq("42").trim());
+    cmd.assert().success().stdout("42\n");
 }
 
 #[test]
 fn cargo_example() {
     let mut cmd = process::Command::cargo_example("example_fixture").unwrap();
     cmd.env("stdout", "42");
-    cmd.assert().success().stdout(predicate::eq("42").trim());
+    cmd.assert().success().stdout("42\n");
 }
 
 #[test]
 fn cargo_example_with_empty_env() {
     let mut cmd = process::Command::cargo_example("example_fixture").unwrap();
     cmd.env_clear().env("stdout", "42");
-    cmd.assert().success().stdout(predicate::eq("42").trim());
+    cmd.assert().success().stdout("42\n");
 }


### PR DESCRIPTION
Eventually `Predicate` is going to move into its own crate so any
breaking change to a predicate will not break `assert_fs`s API.  Having
predicates in the API foils that plan.