### PR TITLE
feat(assert): Context on status failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
     install:
     script:
     - cargo check --tests --all-features
-  - env: CLIPPY_VERSION="0.0.179"
-    rust: nightly-2018-01-12
+  - env: CLIPPY_VERSION="0.0.209"
+    rust: nightly-2018-06-19
     install:
       - travis_wait cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"
     script:


### PR DESCRIPTION
Provide extra context on status failures (success, failure, interrupted,
code).  At the moment, the choice of whether to print stdout or stderr
is context specific.  I have a feeling this won't work as well as I'm
expecting but we'll start here.

Fixes #16