### PR TITLE
fix(assert): Isolate API details

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -107,7 +107,8 @@ struct MessageFilter<'a> {
 
 fn extract_filenames(msg: &escargot::Message, kind: &str) -> Option<path::PathBuf> {
     let filter: MessageFilter = msg.convert().ok()?;
-    if filter.reason != "compiler-artifact" || filter.target.crate_types != ["bin"]
+    if filter.reason != "compiler-artifact"
+        || filter.target.crate_types != ["bin"]
         || filter.target.kind != [kind]
     {
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,9 @@ extern crate predicates;
 #[macro_use]
 extern crate serde;
 
-mod assert;
-pub use assert::*;
+pub mod assert;
+pub use assert::Assert;
+pub use assert::OutputAssertExt;
 pub mod cargo;
 mod cmd;
 pub use cmd::*;

--- a/src/stdin.rs
+++ b/src/stdin.rs
@@ -4,8 +4,8 @@ use std::process;
 
 use assert::Assert;
 use assert::OutputAssertExt;
-use cmd::OutputOkExt;
 use cmd::dump_buffer;
+use cmd::OutputOkExt;
 use errors::OutputError;
 use errors::OutputResult;
 


### PR DESCRIPTION
Ensure we don't expose predicate impls from `predicates` in our public
API.