### PR TITLE
Remove `failure` from API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ keywords = ["cli", "test", "assert", "command", "duct"]
 name = "bin_fixture"
 
 [dependencies]
-failure = "0.1"
-failure_derive = "0.1"
 predicates = "0.5.1"
-escargot = "0.1"
+escargot = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/examples/example_fixture.rs
+++ b/examples/example_fixture.rs
@@ -1,13 +1,10 @@
-extern crate failure;
-
 use std::env;
+use std::error::Error;
 use std::io;
 use std::io::Write;
 use std::process;
 
-use failure::ResultExt;
-
-fn run() -> Result<(), failure::Error> {
+fn run() -> Result<(), Box<Error>> {
     if let Ok(text) = env::var("stdout") {
         println!("{}", text);
     }
@@ -18,8 +15,7 @@ fn run() -> Result<(), failure::Error> {
     let code = env::var("exit")
         .ok()
         .map(|v| v.parse::<i32>())
-        .map_or(Ok(None), |r| r.map(Some))
-        .context("Invalid exit code")?
+        .map_or(Ok(None), |r| r.map(Some))?
         .unwrap_or(0);
     process::exit(code);
 }

--- a/src/bin/bin_fixture.rs
+++ b/src/bin/bin_fixture.rs
@@ -1,13 +1,10 @@
-extern crate failure;
-
 use std::env;
+use std::error::Error;
 use std::io;
 use std::io::Write;
 use std::process;
 
-use failure::ResultExt;
-
-fn run() -> Result<(), failure::Error> {
+fn run() -> Result<(), Box<Error>> {
     if let Ok(text) = env::var("stdout") {
         println!("{}", text);
     }
@@ -18,8 +15,7 @@ fn run() -> Result<(), failure::Error> {
     let code = env::var("exit")
         .ok()
         .map(|v| v.parse::<i32>())
-        .map_or(Ok(None), |r| r.map(Some))
-        .context("Invalid exit code")?
+        .map_or(Ok(None), |r| r.map(Some))?
         .unwrap_or(0);
     process::exit(code);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,6 @@
 #![warn(missing_docs)]
 
 extern crate escargot;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
 extern crate predicates;
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
This is to reduce the API surface to make maintaining compatibility easier.

Fixed #7