### PR TITLE
Docs review

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -12,7 +12,7 @@ use predicates::str::PredicateStrExt;
 use errors::dump_buffer;
 use errors::output_fmt;
 
-/// Assert the state of an [`Output`][Output].
+/// Assert the state of an [`Output`].
 ///
 /// # Examples
 ///
@@ -27,9 +27,9 @@ use errors::output_fmt;
 ///     .success();
 /// ```
 ///
-/// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
+/// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
 pub trait OutputAssertExt {
-    /// Wrap with an interface for that provides assertions on the [`Output`][Output].
+    /// Wrap with an interface for that provides assertions on the [`Output`].
     ///
     /// # Examples
     ///
@@ -44,7 +44,7 @@ pub trait OutputAssertExt {
     ///     .success();
     /// ```
     ///
-    /// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
+    /// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
     fn assert(self) -> Assert;
 }
 
@@ -61,9 +61,9 @@ impl<'c> OutputAssertExt for &'c mut process::Command {
     }
 }
 
-/// Assert the state of an [`Output`][Output].
+/// Assert the state of an [`Output`].
 ///
-/// Create an `Assert` through the [`OutputAssertExt`][OutputAssertExt] trait.
+/// Create an `Assert` through the [`OutputAssertExt`] trait.
 ///
 /// # Examples
 ///
@@ -78,17 +78,17 @@ impl<'c> OutputAssertExt for &'c mut process::Command {
 ///     .success();
 /// ```
 ///
-/// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
-/// [OutputAssertExt]: trait.OutputAssertExt.html
+/// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
+/// [`OutputAssertExt`]: trait.OutputAssertExt.html
 pub struct Assert {
     output: process::Output,
     context: Vec<(&'static str, Box<fmt::Display>)>,
 }
 
 impl Assert {
-    /// Create an `Assert` for a given [`Output`][Output].
+    /// Create an `Assert` for a given [`Output`].
     ///
-    /// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
+    /// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
     pub fn new(output: process::Output) -> Self {
         Self {
             output,
@@ -119,9 +119,9 @@ impl Assert {
         self
     }
 
-    /// Access the contained [`Output`][Output].
+    /// Access the contained [`Output`].
     ///
-    /// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
+    /// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
     pub fn get_output(&self) -> &process::Output {
         &self.output
     }
@@ -334,8 +334,8 @@ impl fmt::Debug for Assert {
     }
 }
 
-/// Used by [`Assert::code`][Assert_code] to convert `Self` into the needed
-/// [`Predicate<i32>`][Predicate].
+/// Used by [`Assert::code`] to convert `Self` into the needed
+/// [`Predicate<i32>`].
 ///
 /// # Examples
 ///
@@ -357,8 +357,8 @@ impl fmt::Debug for Assert {
 ///     .code(predicates::ord::eq(42));
 /// ```
 ///
-/// [Assert_code]: struct.Assert.html#method.code
-/// [Predicate]: https://docs.rs/predicates/0.5.2/predicates/trait.Predicate.html
+/// [`Assert::code`]: struct.Assert.html#method.code
+/// [`Predicate<i32>`]: https://docs.rs/predicates/0.5.2/predicates/trait.Predicate.html
 pub trait IntoCodePredicate<P>
 where
     P: predicates::Predicate<i32>,
@@ -405,12 +405,12 @@ impl IntoCodePredicate<predicates::iter::InPredicate<i32>> for &'static [i32] {
     }
 }
 
-/// Used by [`Assert::stdout`][Assert_stdout] and [`Assert::stderr`][Assert_stderr] to convert Self
-/// into the needed [`Predicate<[u8]>`][Predicate].
+/// Used by [`Assert::stdout`] and [`Assert::stderr`] to convert Self
+/// into the needed [`Predicate<[u8]>`].
 ///
-/// [Assert_stdout]: struct.Assert.html#method.stdout
-/// [Assert_stderr]: struct.Assert.html#method.stderr
-/// [Predicate]: https://docs.rs/predicates/0.5.2/predicates/trait.Predicate.html
+/// [`Assert::stdout`]: struct.Assert.html#method.stdout
+/// [`Assert::stderr`]: struct.Assert.html#method.stderr
+/// [`Predicate<[u8]>`]: https://docs.rs/predicates/0.5.2/predicates/trait.Predicate.html
 pub trait IntoOutputPredicate<P>
 where
     P: predicates::Predicate<[u8]>,
@@ -434,9 +434,9 @@ where
 }
 
 // Keep `predicates` concrete Predicates out of our public API.
-/// [Predicate][Predicate] used by [`IntoOutputPredicate`][IntoOutputPredicate] for bytes.
+/// [Predicate] used by [`IntoOutputPredicate`] for bytes.
 ///
-/// [IntoOutputPredicate]: trait.IntoOutputPredicate.html
+/// [`IntoOutputPredicate`]: trait.IntoOutputPredicate.html
 /// [Predicate]: https://docs.rs/predicates/0.5.2/predicates/trait.Predicate.html
 #[derive(Debug)]
 pub struct BytesContentOutputPredicate(predicates::ord::EqPredicate<&'static [u8]>);
@@ -469,10 +469,11 @@ impl IntoOutputPredicate<BytesContentOutputPredicate> for &'static [u8] {
 }
 
 // Keep `predicates` concrete Predicates out of our public API.
-/// [Predicate][Predicate] used by [`IntoOutputPredicate`][IntoOutputPredicate] for `str`.
+/// [Predicate] used by [`IntoOutputPredicate`] for [`str`].
 ///
-/// [IntoOutputPredicate]: trait.IntoOutputPredicate.html
+/// [`IntoOutputPredicate`]: trait.IntoOutputPredicate.html
 /// [Predicate]: https://docs.rs/predicates/0.5.2/predicates/trait.Predicate.html
+/// [`str`]: https://doc.rust-lang.org/std/primitive.str.html
 #[derive(Debug, Clone)]
 pub struct StrContentOutputPredicate(
     predicates::str::Utf8Predicate<predicates::str::DifferencePredicate>,

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -97,6 +97,20 @@ impl Assert {
     }
 
     /// Clarify failures with additional context.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use assert_cmd::prelude::*;
+    ///
+    /// use std::process::Command;
+    ///
+    /// Command::main_binary()
+    ///     .unwrap()
+    ///     .assert()
+    ///     .append_context("main", "no args")
+    ///     .success();
+    /// ```
     pub fn append_context<D>(mut self, name: &'static str, context: D) -> Self
     where
         D: fmt::Display + 'static,

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -65,8 +65,8 @@ where
     /// use std::process::Command;
     ///
     /// Command::main_binary()
-    ///     .unwrap()
-    ///     .unwrap();
+    ///     .unwrap()  // get cargo binary
+    ///     .unwrap(); // run it
     /// ```
     ///
     /// [Command]: https://doc.rust-lang.org/std/process/struct.Command.html

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -4,7 +4,9 @@ use errors::dump_buffer;
 use errors::OutputError;
 use errors::OutputResult;
 
-/// Convert an [`Output`][Output] to an [`OutputResult`][OutputResult].
+/// Converts a type to an [`OutputResult`].
+///
+/// This is for example implemented on [`std::process::Output`].
 ///
 /// # Examples
 ///
@@ -19,8 +21,8 @@ use errors::OutputResult;
 /// assert!(result.is_ok());
 /// ```
 ///
-/// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
-/// [OutputResult]: type.OutputResult.html
+/// [`std::process::Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
+/// [`OutputResult`]: type.OutputResult.html
 pub trait OutputOkExt
 where
     Self: ::std::marker::Sized,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,9 +3,9 @@ use std::fmt;
 use std::process;
 use std::str;
 
-/// [`Output`][Output] represented as a [`Result`][Result].
+/// [`Output`] represented as a [`Result`].
 ///
-/// Generally produced by [`OutputOkExt`][OutputOkExt].
+/// Generally produced by [`OutputOkExt`].
 ///
 /// # Examples
 ///
@@ -20,14 +20,14 @@ use std::str;
 /// assert!(result.is_ok());
 /// ```
 ///
-/// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
-/// [Result]: https://doc.rust-lang.org/std/result/enum.Result.html
-/// [OutputOkExt]: trait.OutputOkExt.html
+/// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
+/// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
+/// [`OutputOkExt`]: trait.OutputOkExt.html
 pub type OutputResult = Result<process::Output, OutputError>;
 
-/// [`Command`][Command] error.
+/// [`Command`] error.
 ///
-/// Generally produced by [`OutputOkExt`][OutputOkExt].
+/// Generally produced by [`OutputOkExt`].
 ///
 /// # Examples
 ///
@@ -42,8 +42,8 @@ pub type OutputResult = Result<process::Output, OutputError>;
 ///     .unwrap_err();
 /// ```
 ///
-/// [Command]: https://doc.rust-lang.org/std/process/struct.Command.html
-/// [OutputOkExt]: trait.OutputOkExt.html
+/// [`Command`]: https://doc.rust-lang.org/std/process/struct.Command.html
+/// [`OutputOkExt`]: trait.OutputOkExt.html
 #[derive(Debug)]
 pub struct OutputError {
     cmd: Option<String>,
@@ -52,10 +52,10 @@ pub struct OutputError {
 }
 
 impl OutputError {
-    /// Convert [`Output`][Output] into an [`Error`][Error].
+    /// Convert [`Output`] into an [`Error`].
     ///
-    /// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
-    /// [Error]: https://doc.rust-lang.org/std/error/trait.Error.html
+    /// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
+    /// [`Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
     pub fn new(output: process::Output) -> Self {
         Self {
             cmd: None,
@@ -64,9 +64,9 @@ impl OutputError {
         }
     }
 
-    /// For errors that happen in creating a [`Output`][Output].
+    /// For errors that happen in creating a [`Output`].
     ///
-    /// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
+    /// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
     pub fn with_cause<E>(cause: E) -> Self
     where
         E: Error + Send + Sync + 'static,
@@ -90,7 +90,7 @@ impl OutputError {
         self
     }
 
-    /// Access the contained [`Output`][Output].
+    /// Access the contained [`Output`].
     ///
     /// # Examples
     ///
@@ -109,7 +109,7 @@ impl OutputError {
     /// assert_eq!(Some(42), output.status.code());
     /// ```
     ///
-    /// [Output]: https://doc.rust-lang.org/std/process/struct.Output.html
+    /// [`Output`]: https://doc.rust-lang.org/std/process/struct.Output.html
     pub fn as_output(&self) -> Option<&process::Output> {
         match self.cause {
             OutputCause::Expected(ref e) => Some(&e.output),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,22 +24,22 @@
 //! ## Relevant crates
 //!
 //! Other crates that might be useful in testing command line programs.
-//! - [duct][duct] for orchestrating multiple processes.
-//! - [`assert_fs`][assert_fs] for filesystem fixtures and assertions.
-//! - [dir-diff][dir-diff] for testing file side-effects.
-//! - [tempfile][tempfile] for scratchpad directories.
+//! - [duct] for orchestrating multiple processes.
+//! - [assert_fs] for filesystem fixtures and assertions.
+//! - [dir-diff] for testing file side-effects.
+//! - [tempfile] for scratchpad directories.
 //!
 //! ## Migrating from `assert_cli` v0.6
 //!
-//! - More flexible, reusable assertions (also used by [`assert_fs`][assert_fs]).
 //! `assert_cmd` is the successor to [the original `assert_cli`][assert_cli]:
+//! - More flexible, reusable assertions (also used by [assert_fs]).
 //! - Can integrate with other process-management crates, like `duct`.
 //! - Addresses several architectural problems.
 //!
 //! Key points in migrating from `assert_cli`:
-//! - [`Command`][Command] is extended with traits rather than being wrapping in custom logic.
+//! - [`Command`] is extended with traits rather than being wrapping in custom logic.
 //! - The command-under-test is run eagerly, with assertions happening immediately.
-//! - [`success()`][success] is not implicit and requires being explicitly called.
+//! - [`success()`] is not implicit and requires being explicitly called.
 //! - `stdout`/`stderr` aren't automatically trimmed before being passed to the `Predicate`.
 //!
 //! [assert_cli]: https://crates.io/crates/assert_cli/0.6.3
@@ -47,8 +47,8 @@
 //! [tempfile]: https://crates.io/crates/tempfile
 //! [duct]: https://crates.io/crates/duct
 //! [assert_fs]: https://crates.io/crates/assert_fs
-//! [Command]: https://doc.rust-lang.org/std/process/struct.Command.html
-//! [success]: struct.Assert.html#method.success
+//! [`Command`]: https://doc.rust-lang.org/std/process/struct.Command.html
+//! [`success()`]: struct.Assert.html#method.success
 
 #![warn(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@
 //!
 //! ## Migrating from `assert_cli` v0.6
 //!
-//! `assert_cmd` is the successor to `assert_cli`:
 //! - More flexible, reusable assertions (also used by [`assert_fs`][assert_fs]).
+//! `assert_cmd` is the successor to [the original `assert_cli`][assert_cli]:
 //! - Can integrate with other process-management crates, like `duct`.
 //! - Addresses several architectural problems.
 //!
@@ -42,6 +42,7 @@
 //! - [`success()`][success] is not implicit and requires being explicitly called.
 //! - `stdout`/`stderr` aren't automatically trimmed before being passed to the `Predicate`.
 //!
+//! [assert_cli]: https://crates.io/crates/assert_cli/0.6.3
 //! [dir-diff]: https://crates.io/crates/dir-diff
 //! [tempfile]: https://crates.io/crates/tempfile
 //! [duct]: https://crates.io/crates/duct


### PR DESCRIPTION
Some things I noticed while reading the docs.

One thing that confuses me are phrases like

> Assert the state of an [`Output`].

Where output is then linked to `std::process::Output`. Is this wise? The library is in theory generic over the output type. I changed the wording in the `OutputOkExt` trait docs, but I'm not entirely happy with it (it's too long).

I've also taken the liberty to simplifying a lot of markdown links to shortcut reference links. Once <https://github.com/rust-lang/rust/issues/43466> hits stable you can probably remove many of the link reference definitions.