### PR TITLE
chore: Add cargo benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,14 @@ matrix:
     script:
       - cargo clippy --all-features -- -D clippy
 
+env:
+  global:
+  - WHEN=0.1.0
+
 install:
 - rustc -Vv
 - cargo -V
+- if [[ `cargo-when --version` != *$WHEN ]] ; then travis_wait cargo install cargo-when --force --vers $WHEN; fi
 - export PATH=$HOME/.cargo/bin:$PATH
 
 script:
@@ -36,6 +41,7 @@ script:
 - cargo check --verbose --all-features
 - rm -rf target/debug/deps/*assert_cmd*  # Avoid docmatic problems
 - cargo test  --verbose --all-features
+- cargo when --channel nightly bench --all
 
 branches:
   only:

--- a/benches/cargo.rs
+++ b/benches/cargo.rs
@@ -1,0 +1,24 @@
+#![feature(test)]
+
+extern crate test;
+extern crate escargot;
+
+use std::process;
+
+fn escargot_build() -> Result<process::Command, escargot::CargoError> {
+    let cmd = escargot::CargoBuild::new()
+        .bin("bin_fixture")
+        .current_release()
+        .current_target()
+        .run()?
+        .command();
+    Ok(cmd)
+}
+
+// It is easier to benchmark this than to benchmark `main_binary` which would include the cost of
+// running the binary.
+#[bench]
+fn escargot_rebuild(b: &mut test::Bencher) {
+    let _ = escargot_build();
+    b.iter(|| {let _ = escargot_build(); });
+}


### PR DESCRIPTION
This is to help us identify if cargo has addressed #6.