### PR TITLE
Add ability to run bin and example from other crates in workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "bin_fixture"
 predicates = { version = "1.0", default-features = false, features = ["difference"] }
 predicates-core = "1.0"
 predicates-tree = "1.0"
-escargot = "0.3"
+escargot = "0.4"
 
 [dev-dependencies]
 docmatic = "0.1"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -144,6 +144,46 @@ where
     /// [`Command`]: https://doc.rust-lang.org/std/process/struct.Command.html
     /// [`cargo`]: index.html
     fn cargo_example<S: AsRef<ffi::OsStr>>(name: S) -> Result<Self, CargoError>;
+
+    /// Create a [`Command`] to run a specific binary of a specific crate from workspaces.
+    ///
+    /// See the [`cargo` module documentation][`cargo`] for caveats and workarounds.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use assert_cmd::prelude::*;
+    ///
+    /// use std::process::Command;
+    ///
+    /// let mut cmd = Command::cargo_crate_bin("assert_cmd", "bin_fixture")
+    ///     .unwrap();
+    /// let output = cmd.unwrap();
+    /// ```
+    ///
+    /// [`Command`]: https://doc.rust-lang.org/std/process/struct.Command.html
+    /// [`cargo`]: index.html
+    fn cargo_crate_bin<S: AsRef<ffi::OsStr>>(package: S, name: S) -> Result<Self, CargoError>;
+
+    /// Create a [`Command`] to run a specific example of a specific crate from workspaces.
+    ///
+    /// See the [`cargo` module documentation][`cargo`] for caveats and workarounds.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use assert_cmd::prelude::*;
+    ///
+    /// use std::process::Command;
+    ///
+    /// let mut cmd = Command::cargo_crate_example("assert_cmd", "example_fixture")
+    ///     .unwrap();
+    /// let output = cmd.unwrap();
+    /// ```
+    ///
+    /// [`Command`]: https://doc.rust-lang.org/std/process/struct.Command.html
+    /// [`cargo`]: index.html
+    fn cargo_crate_example<S: AsRef<ffi::OsStr>>(package: S, name: S) -> Result<Self, CargoError>;
 }
 
 impl CommandCargoExt for process::Command {
@@ -168,6 +208,28 @@ impl CommandCargoExt for process::Command {
 
     fn cargo_example<S: AsRef<ffi::OsStr>>(name: S) -> Result<Self, CargoError> {
         let runner = escargot::CargoBuild::new()
+            .example(name)
+            .current_release()
+            .current_target()
+            .run()
+            .map_err(CargoError::with_cause)?;
+        Ok(runner.command())
+    }
+
+    fn cargo_crate_bin<S: AsRef<ffi::OsStr>>(package: S, name: S) -> Result<Self, CargoError> {
+        let runner = escargot::CargoBuild::new()
+            .package(package)
+            .bin(name)
+            .current_release()
+            .current_target()
+            .run()
+            .map_err(CargoError::with_cause)?;
+        Ok(runner.command())
+    }
+
+    fn cargo_crate_example<S: AsRef<ffi::OsStr>>(package: S, name: S) -> Result<Self, CargoError> {
+        let runner = escargot::CargoBuild::new()
+            .package(package)
             .example(name)
             .current_release()
             .current_target()


### PR DESCRIPTION
This option adds an ability to run targets from different packages/crates in workspaces.

Workspaces contain several crates and it is a common situation when integration tests are located in a separate crate.

There is an open question for naming: `crate`(used in general description) vs `package` (used in cargo). I selected `package` in escargot, because it represents cargo arguments, but use `crate` here, because it is a general term: crates in workspaces.