### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -163,10 +163,6 @@ impl CargoError {
 }
 
 impl Error for CargoError {
-    fn description(&self) -> &str {
-        "Cargo command failed."
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         self.cause.as_ref().map(|c| {
             let c: &dyn Error = c.as_ref();
@@ -191,10 +187,6 @@ struct NotFoundError {
 }
 
 impl Error for NotFoundError {
-    fn description(&self) -> &str {
-        "Cargo command not found."
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         None
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -243,10 +243,6 @@ impl OutputError {
 }
 
 impl Error for OutputError {
-    fn description(&self) -> &str {
-        "Command failed."
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         if let OutputCause::Unexpected(ref err) = self.cause {
             Some(err.as_ref())


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes an implementation of `description` in all error types

Related PR: https://github.com/rust-lang/rust/pull/66919