### PR TITLE
Remove deprecated Error::cause

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -162,14 +162,7 @@ impl CargoError {
     }
 }
 
-impl Error for CargoError {
-    fn cause(&self) -> Option<&dyn Error> {
-        self.cause.as_ref().map(|c| {
-            let c: &dyn Error = c.as_ref();
-            c
-        })
-    }
-}
+impl Error for CargoError {}
 
 impl fmt::Display for CargoError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -186,11 +179,7 @@ struct NotFoundError {
     path: path::PathBuf,
 }
 
-impl Error for NotFoundError {
-    fn cause(&self) -> Option<&dyn Error> {
-        None
-    }
-}
+impl Error for NotFoundError {}
 
 impl fmt::Display for NotFoundError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/output.rs
+++ b/src/output.rs
@@ -242,15 +242,7 @@ impl OutputError {
     }
 }
 
-impl Error for OutputError {
-    fn cause(&self) -> Option<&dyn Error> {
-        if let OutputCause::Unexpected(ref err) = self.cause {
-            Some(err.as_ref())
-        } else {
-            None
-        }
-    }
-}
+impl Error for OutputError {}
 
 impl fmt::Display for OutputError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
`Error::cause` has been documented as deprecated.

This PR removes `Error::cause` implementation

Related PR: https://github.com/assert-rs/assert_cmd/pull/86