### PR TITLE
fix(docs): List v0.12 in Cargo.toml snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-assert_cmd = "0.11"
+assert_cmd = "0.12"
 ```
 
 ## Example


### PR DESCRIPTION
Currently the latest version is not listed in the `Cargo.toml` snippet. This causes the trivial example to fail as it requires the command wrapper listed in d159e875aee71841198c67cd1a4e848b8bb9e465.