### PR TITLE
Bump example version for Cargo.toml dep

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! assert_cmd = "0.11"
+//! assert_cmd = "0.12"
 //! ```
 //!
 //! ## Overview


### PR DESCRIPTION
:wave: 

I was giving this crate a try and ran into an issue with the first example so I thought I'd put up the fix. Thanks for taking a look! 

Before this commit, following the documentation's first example ended up in a compile
error because the `use` expression for the `Command` struct wasn't compatible with this crate's `0.11` version (the `Install` step says to use `assert_cmd = "0.11"`)

This is the error using `0.11` produces:

```
error[E0432]: unresolved import `assert_cmd::Command`
 --> tests/tests.rs:2:5
  |
2 | use assert_cmd::Command;
  |     ^^^^^^^^^^^^^^^^^^^ no `Command` in the root
```

After this commit, the `use` expression is compatible with the crate.

Thanks for taking a look!