### PR TITLE
Can't find bin_fixture bin, specify bin.path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [[bin]]
 name = "bin_fixture"
+path = "src/bin/bin_fixture.rs"
 
 [dependencies]
 predicates = { version = "1.0", default-features = false, features = ["difference"] }


### PR DESCRIPTION
We are using your library for https://github.com/paritytech/substrate/ and there is some problem on the CI that I cannot reproduce locally...

```
 error: failed to download `assert_cmd v1.0.1`
Caused by:
  unable to get packages from source
Caused by:
  failed to parse manifest at `/ci-cache/substrate/cargo/cargo-check-benches/registry/src/github.com-1ecc6299db9ec823/assert_cmd-1.0.1/Cargo.toml`
Caused by:
  can't find `bin_fixture` bin, specify bin.path
```
Full logs [here](https://gitlab.parity.io/parity/substrate/-/jobs/442691).

I made and tested this patch to fix it. Would it be possible to make a release of your crate? The sooner the better. Thanks!! 