### PR TITLE
Add `Command::absolute_path` constructor

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -66,6 +66,30 @@ impl Command {
         Ok(Self::from_std(cmd))
     }
 
+    /// Create a [`Command`] to run a specific binary of the current crate using absolute
+    /// path.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use assert_cmd::prelude::*;
+    ///
+    /// use std::process::Command;
+    ///
+    /// let mut cmd = Command::absolute_path(env!("CARGO_BIN_EXE_bin_fixture"))
+    ///     .unwrap();
+    /// let output = cmd.unwrap();
+    /// println!("{:?}", output);
+    /// ```
+    ///
+    /// [`Command`]: https://doc.rust-lang.org/std/process/struct.Command.html
+    pub fn absolute_path<T: Into<path::PathBuf>>(
+        path: T,
+    ) -> Result<Self, crate::cargo::CargoError> {
+        let cmd = crate::cargo::from_path(path)?;
+        Ok(Self::from_std(cmd))
+    }
+
     /// Write `buffer` to `stdin` when the `Command` is run.
     ///
     /// # Examples

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -52,3 +52,10 @@ fn cargo_bin_example_2() {
     let output = cmd.unwrap();
     println!("{:?}", output);
 }
+
+#[test]
+fn cargo_bin_exe() {
+    let cmd = Command::absolute_path(env!("CARGO_BIN_EXE_bin_fixture"));
+    let output = cmd.unwrap();
+    println!("{:?}", output);
+}


### PR DESCRIPTION
I'm not sure if it is the right approach to fix the #101 issue, but I would like to use the `CARGO_BIN_EXE_...` environment variable.

Additionally I'm not sure about naming. Logically it would be better to name the constructor `from_absolute_path`, but is somewhat too long and existing `cargo_bin` constructor did not use the use "from" naming either.