### PR TITLE
Better debug print of stdin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ predicates-core = "1.0"
 predicates-tree = "1.0"
 doc-comment = "0.3"
 wait-timeout = "0.2.0"
+bstr = "0.2.14"
 
 [dev-dependencies]
 escargot = "0.5"

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -9,8 +9,8 @@ use std::str;
 use predicates::str::PredicateStrExt;
 use predicates_tree::CaseTreeExt;
 
-use crate::output::dump_buffer;
 use crate::output::output_fmt;
+use crate::output::DebugBytes;
 
 /// Assert the state of an [`Output`].
 ///
@@ -145,14 +145,14 @@ impl Assert {
             let actual_code = self.output.status.code().unwrap_or_else(|| {
                 panic!(
                     "Unexpected failure.\ncode=<interrupted>\nstderr=```{}```\n{}",
-                    dump_buffer(&self.output.stderr),
+                    DebugBytes::new(&self.output.stderr),
                     self
                 )
             });
             panic!(
                 "Unexpected failure.\ncode-{}\nstderr=```{}```\n{}",
                 actual_code,
-                dump_buffer(&self.output.stderr),
+                DebugBytes::new(&self.output.stderr),
                 self
             );
         }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -10,8 +10,8 @@ use std::process;
 
 use crate::assert::Assert;
 use crate::assert::OutputAssertExt;
-use crate::output::dump_buffer;
 use crate::output::DebugBuffer;
+use crate::output::DebugBytes;
 use crate::output::OutputError;
 use crate::output::OutputOkExt;
 use crate::output::OutputResult;
@@ -536,14 +536,14 @@ impl<'c> OutputOkExt for &'c mut Command {
                     panic!(
                         "Completed successfully:\ncommand=`{:?}`\nstdin=```{}```\nstdout=```{}```",
                         self.cmd,
-                        dump_buffer(&stdin),
-                        dump_buffer(&output.stdout)
+                        DebugBytes::new(&stdin),
+                        DebugBytes::new(&output.stdout)
                     )
                 } else {
                     panic!(
                         "Completed successfully:\ncommand=`{:?}`\nstdout=```{}```",
                         self.cmd,
-                        dump_buffer(&output.stdout)
+                        DebugBytes::new(&output.stdout)
                     )
                 }
             }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,11 +1,10 @@
 //! Simplify one-off runs of programs.
 
+use bstr::ByteSlice;
 use std::error::Error;
 use std::fmt;
 use std::process;
 use std::str;
-
-use bstr::ByteSlice;
 
 /// Converts a type to an [`OutputResult`].
 ///
@@ -90,7 +89,7 @@ where
         match self.ok() {
             Ok(output) => panic!(
                 "Command completed successfully\nstdout=```{}```",
-                dump_buffer(&output.stdout)
+                DebugBytes::new(&output.stdout)
             ),
             Err(err) => err,
         }
@@ -124,7 +123,7 @@ impl<'c> OutputOkExt for &'c mut process::Command {
             Ok(output) => panic!(
                 "Completed successfully:\ncommand=`{:?}`\nstdout=```{}```",
                 self,
-                dump_buffer(&output.stdout)
+                DebugBytes::new(&output.stdout)
             ),
             Err(err) => err,
         }
@@ -295,30 +294,29 @@ pub(crate) fn output_fmt(output: &process::Output, f: &mut fmt::Formatter<'_>) -
         writeln!(f, "code=<interrupted>")?;
     }
 
-    write!(f, "stdout=```")?;
-    write_buffer(&output.stdout, f)?;
-    writeln!(f, "```")?;
-
-    write!(f, "stderr=```")?;
-    write_buffer(&output.stderr, f)?;
-    writeln!(f, "```")?;
-
+    write!(
+        f,
+        "stdout=```{}```\nstderr=```{}```\n",
+        DebugBytes::new(&output.stdout),
+        DebugBytes::new(&output.stderr),
+    )?;
     Ok(())
 }
 
-pub(crate) fn dump_buffer(buffer: &[u8]) -> String {
-    if let Ok(buffer) = str::from_utf8(buffer) {
-        buffer.to_string()
-    } else {
-        format!("{:?}", buffer)
+#[derive(Debug)]
+pub(crate) struct DebugBytes<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> DebugBytes<'a> {
+    pub(crate) fn new(bytes: &'a [u8]) -> Self {
+        DebugBytes { bytes }
     }
 }
 
-pub(crate) fn write_buffer(buffer: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if let Ok(buffer) = str::from_utf8(buffer) {
-        write!(f, "{}", buffer)
-    } else {
-        write!(f, "{}", buffer.as_bstr())
+impl<'a> fmt::Display for DebugBytes<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format_bytes(self.bytes, f)
     }
 }
 
@@ -335,23 +333,27 @@ impl DebugBuffer {
 
 impl fmt::Display for DebugBuffer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        const MIN_OVERFLOW: usize = 8192;
-        const MAX_START: usize = 2048;
-        const MAX_END: usize = 2048;
-        const MAX_PRINTED: usize = MAX_START + MAX_END;
-        assert!(MAX_PRINTED < MIN_OVERFLOW);
+        format_bytes(&self.buffer, f)
+    }
+}
 
-        if self.buffer.len() >= MIN_OVERFLOW {
-            write!(
-                f,
-                "<{} bytes total>{:?}...<{} bytes omitted>...{:?}",
-                self.buffer.len(),
-                self.buffer[..MAX_START].as_bstr(),
-                self.buffer.len() - MAX_PRINTED,
-                self.buffer[self.buffer.len() - MAX_END..].as_bstr(),
-            )
-        } else {
-            write!(f, "{:?}", self.buffer.as_bstr())
-        }
+fn format_bytes(data: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    const MIN_OVERFLOW: usize = 8192;
+    const MAX_START: usize = 2048;
+    const MAX_END: usize = 2048;
+    const MAX_PRINTED: usize = MAX_START + MAX_END;
+    assert!(MAX_PRINTED < MIN_OVERFLOW);
+
+    if data.len() >= MIN_OVERFLOW {
+        write!(
+            f,
+            "<{} bytes total>{:?}...<{} bytes omitted>...{:?}",
+            data.len(),
+            data[..MAX_START].as_bstr(),
+            data.len() - MAX_PRINTED,
+            data[data.len() - MAX_END..].as_bstr(),
+        )
+    } else {
+        write!(f, "{:?}", data.as_bstr())
     }
 }


### PR DESCRIPTION
1. Even if stdout is not fully utf-8, we print all ASCII printable
   characters verbatim and hex-escapes `\xAB` for non-printable
2. For inputs larger than 8KiB we only print first and last 2KiB and
   omit bytes in the middle.

This helps reading error messages on larger stdin data (in my use case assert_cmd dumped ~440Mb of data on the terminal).