### PR TITLE
fix: Typo stager -> assert_cmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to stager
+# Contributing to assert_cmd
 
 Thanks for wanting to contribute! There are many ways to contribute and we
 appreciate any level you're willing to do.


### PR DESCRIPTION
it looks like CONTRIBUTING.md was copied from
[stager](https://github.com/crate-ci/stager)
and the name was just never updated