### PR TITLE
fix(cargo): Take advantge of `CARGO_BIN_EXE`

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -201,5 +201,8 @@ pub fn cargo_bin<S: AsRef<str>>(name: S) -> path::PathBuf {
 }
 
 fn cargo_bin_str(name: &str) -> path::PathBuf {
-    target_dir().join(format!("{}{}", name, env::consts::EXE_SUFFIX))
+    let env_var = format!("CARGO_BIN_EXE_{}", name);
+    std::env::var_os(&env_var)
+        .map(|p| p.into())
+        .unwrap_or_else(|| target_dir().join(format!("{}{}", name, env::consts::EXE_SUFFIX)))
 }


### PR DESCRIPTION
This was added to cargo in 1.43 and should make our binary lookup more
reliable.  1.43 should be pretty wide spread but if someone hasn't
upgraded, then we'll still fall back to the old logic.

Fixes #101