### PR TITLE
fix(diff): Remove duplicated output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Breaking Changes
+
+- `predicates::str::diff` was removed
+- `predicates::str::similar` was renamed to `diff`
+- The `difference` feature flag was renamed to `diff`
+- `diff().split` and `diff().distance` were removed
+
+#### Fixes
+
+- Shrink the output of Diffs because its redundant
+- Moved off of an unmaintained Diff library
+
 ## [1.0.4] - 2021-05-12
 
 #### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ maintenance = { status = "passively-maintained" }
 name = "bin_fixture"
 
 [dependencies]
-predicates = { version = "1.0", default-features = false, features = ["difference"] }
-predicates-core = "1.0"
-predicates-tree = "1.0"
+predicates = { version = "1.0", default-features = false, features = ["diff"], path="../predicates-rs" }
+predicates-core = {version="1.0", path="../predicates-rs/crates/core" }
+predicates-tree = {version="1.0", path="../predicates-rs/crates/tree" }
+
 doc-comment = "0.3"
 wait-timeout = "0.2.0"
 bstr = "0.2.14"

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -295,7 +295,7 @@ impl Assert {
     ///     .env("stdout", "hello")
     ///     .env("stderr", "world")
     ///     .assert()
-    ///     .stdout(predicate::str::similar("hello\n"));
+    ///     .stdout(predicate::str::diff("hello\n"));
     /// ```
     ///
     /// Accepting bytes:
@@ -379,7 +379,7 @@ impl Assert {
     ///     .env("stdout", "hello")
     ///     .env("stderr", "world")
     ///     .assert()
-    ///     .stderr(predicate::str::similar("world\n"));
+    ///     .stderr(predicate::str::diff("world\n"));
     /// ```
     ///
     /// Accepting bytes:
@@ -654,7 +654,7 @@ impl IntoCodePredicate<InCodePredicate> for &'static [i32] {
 ///     .env("stdout", "hello")
 ///     .env("stderr", "world")
 ///     .assert()
-///     .stdout(predicate::str::similar("hello\n").from_utf8());
+///     .stdout(predicate::str::diff("hello\n").from_utf8());
 ///
 /// // which can be shortened to:
 /// Command::cargo_bin("bin_fixture")
@@ -785,12 +785,12 @@ pub struct StrContentOutputPredicate(
 
 impl StrContentOutputPredicate {
     pub(crate) fn from_str(value: &'static str) -> Self {
-        let pred = predicates::str::similar(value).from_utf8();
+        let pred = predicates::str::diff(value).from_utf8();
         StrContentOutputPredicate(pred)
     }
 
     pub(crate) fn from_string(value: String) -> Self {
-        let pred = predicates::str::similar(value).from_utf8();
+        let pred = predicates::str::diff(value).from_utf8();
         StrContentOutputPredicate(pred)
     }
 }
@@ -862,7 +862,7 @@ impl IntoOutputPredicate<StrContentOutputPredicate> for &'static str {
 ///     .env("stdout", "hello")
 ///     .env("stderr", "world")
 ///     .assert()
-///     .stderr(predicate::str::similar("world\n"));
+///     .stderr(predicate::str::diff("world\n"));
 /// ```
 #[derive(Debug, Clone)]
 pub struct StrOutputPredicate<P: predicates_core::Predicate<str>>(

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -93,7 +93,7 @@ fn stdout_example() {
         .env("stdout", "hello")
         .env("stderr", "world")
         .assert()
-        .stdout(predicate::str::similar("hello\n"));
+        .stdout(predicate::str::diff("hello\n"));
 
     Command::cargo_bin("bin_fixture")
         .unwrap()
@@ -131,7 +131,7 @@ fn stderr_example() {
         .env("stdout", "hello")
         .env("stderr", "world")
         .assert()
-        .stderr(predicate::str::similar("world\n"));
+        .stderr(predicate::str::diff("world foo\n"));
 
     Command::cargo_bin("bin_fixture")
         .unwrap()


### PR DESCRIPTION
In the tree view, we already show the original and the current value, we
shouldnt show an entire Diff that is only parseable by color.

In changing this, we removed the more cosmetic atom selector.  We also
removed the edit distance, since there isn't a known case for it.  Let
us know if you needed this!

Fixes #94
Fixes #105