### PR TITLE
fix: Address `needles_borrow` warnings

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -463,7 +463,7 @@ impl Assert {
     fn stdout_impl(self, pred: &dyn predicates_core::Predicate<[u8]>) -> AssertResult {
         {
             let actual = &self.output.stdout;
-            if let Some(case) = pred.find_case(false, &actual) {
+            if let Some(case) = pred.find_case(false, actual) {
                 return Err(self.into_error(AssertReason::UnexpectedStdout {
                     case_tree: CaseTree(case.tree()),
                 }));
@@ -558,7 +558,7 @@ impl Assert {
     fn stderr_impl(self, pred: &dyn predicates_core::Predicate<[u8]>) -> AssertResult {
         {
             let actual = &self.output.stderr;
-            if let Some(case) = pred.find_case(false, &actual) {
+            if let Some(case) = pred.find_case(false, actual) {
                 return Err(self.into_error(AssertReason::UnexpectedStderr {
                     case_tree: CaseTree(case.tree()),
                 }));

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -533,7 +533,7 @@ impl<'c> OutputOkExt for &'c mut Command {
                     panic!(
                         "Completed successfully:\ncommand=`{:?}`\nstdin=```{}```\nstdout=```{}```",
                         self.cmd,
-                        DebugBytes::new(&stdin),
+                        DebugBytes::new(stdin),
                         DebugBytes::new(&output.stdout)
                     )
                 } else {


### PR DESCRIPTION
Sorry, I should have run Clippy before submitting #128. My sincere apologies.