### PR TITLE
feat: Refine `append_context` bounds

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -180,7 +180,7 @@ impl fmt::Display for AssertError {
 /// [`Output`]: std::process::Output
 pub struct Assert {
     output: process::Output,
-    context: Vec<(&'static str, Box<dyn fmt::Display>)>,
+    context: Vec<(&'static str, Box<dyn fmt::Display + Send + Sync>)>,
 }
 
 impl Assert {
@@ -218,7 +218,7 @@ impl Assert {
     /// ```
     pub fn append_context<D>(mut self, name: &'static str, context: D) -> Self
     where
-        D: fmt::Display + 'static,
+        D: fmt::Display + Send + Sync + 'static,
     {
         self.context.push((name, Box::new(context)));
         self


### PR DESCRIPTION
Full disclosure: what is proposed is a **breaking change** for `assert_cmd`, so I won't be offended if it's rejected.

This PR (`*`) restricts `append_context`'s second argument (`context`) to be `Send + Sync`.

(`*`) will allow (`**`) instances of `Assert` to be `Send + Sync`.

And (`**`) combined with a PR to be submitted separately to `predicates-rs` will allow `AssertError`s (introduced in #128) to be converted to [`anyhow::Error`](https://docs.rs/anyhow/1.0.42/anyhow/struct.Error.html)s.

`anyhow::Error`'s requirement for `Send + Sync` is discussed [here](https://github.com/dtolnay/anyhow/issues/81).

Clearly, it would be untenable to break `assert_cmd` for every package it might be used with. But `anyhow` is pretty widely used. Moreover, the proposed bounds are relatively common and involve only standard traits.

Here's a sample program that doesn't compile now, but would compile with this and the `predicates-rs` PR:
```rust
use assert_cmd::prelude::*;
use std::process::Command;

pub fn foo() -> anyhow::Result<()> {
    let _ = Command::new("echo").assert().try_success()?;
    Ok(())
}
```

An alternative to enabling conversion to `anyhow::Error` would be to change `AssertError`'s representation. But I cannot immediately see how one could do that and preserve its current functionality.