### PR TITLE
fix(assert): Show caller on panic 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.44.0"
+    name: "Check MSRV: 1.46.0"
     needs: smoke
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +78,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0  # MSRV
+        toolchain: 1.46.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v1
@@ -133,7 +133,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0  # MSRV
+        toolchain: 1.46.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -66,9 +66,9 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.44.0  # MSRV
+        - 1.46.0  # MSRV
         - stable
-    continue-on-error: ${{ matrix.rust != '1.44.0' }}  # MSRV
+    continue-on-error: ${{ matrix.rust != '1.46.0' }}  # MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Fixes
+
+- Show caller for panic, rather than `assert_cmd`
+
 ## [2.0.0] - 2021-08-05
 
 ### Breaking Changes

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -151,6 +151,7 @@ impl Assert {
     ///     .assert()
     ///     .success();
     /// ```
+    #[track_caller]
     pub fn success(self) -> Self {
         self.try_success().unwrap_or_else(AssertError::panic)
     }
@@ -179,6 +180,7 @@ impl Assert {
     ///     .assert()
     ///     .failure();
     /// ```
+    #[track_caller]
     pub fn failure(self) -> Self {
         self.try_failure().unwrap_or_else(AssertError::panic)
     }
@@ -192,6 +194,7 @@ impl Assert {
     }
 
     /// Ensure the command aborted before returning a code.
+    #[track_caller]
     pub fn interrupted(self) -> Self {
         self.try_interrupted().unwrap_or_else(AssertError::panic)
     }
@@ -252,6 +255,7 @@ impl Assert {
     ///     .code(&[2, 42] as &[i32]);
     /// ```
     ///
+    #[track_caller]
     pub fn code<I, P>(self, pred: I) -> Self
     where
         I: IntoCodePredicate<P>,
@@ -349,6 +353,7 @@ impl Assert {
     ///     .stdout("hello\n");
     /// ```
     ///
+    #[track_caller]
     pub fn stdout<I, P>(self, pred: I) -> Self
     where
         I: IntoOutputPredicate<P>,
@@ -444,6 +449,7 @@ impl Assert {
     ///     .stderr("world\n");
     /// ```
     ///
+    #[track_caller]
     pub fn stderr<I, P>(self, pred: I) -> Self
     where
         I: IntoOutputPredicate<P>,
@@ -1019,6 +1025,7 @@ enum AssertReason {
 }
 
 impl AssertError {
+    #[track_caller]
     fn panic<T>(self) -> T {
         panic!("{}", self)
     }

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1020,7 +1020,7 @@ enum AssertReason {
 
 impl AssertError {
     fn panic<T>(self) -> T {
-        panic!("{}", self.to_string())
+        panic!("{}", self)
     }
 }
 


### PR DESCRIPTION
Thanks to Rust 1.46, we can show the caller on panic, rather than
`assert_cmd`, as if `assert_cmd` was written with macros.

Fixes #133