### PR TITLE
feat: allow getting the Assert from an AssertError

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1035,6 +1035,33 @@ impl AssertError {
     fn panic<T>(self) -> T {
         panic!("{}", self)
     }
+
+    /// Returns the [`Assert`] wrapped into the [`Result`] produced by
+    /// the `try_` variants of the [`Assert`] methods.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use assert_cmd::prelude::*;
+    ///
+    /// use std::process::Command;
+    /// use predicates::prelude::*;
+    ///
+    /// let result = Command::new("echo")
+    ///     .assert();
+    ///
+    /// match result.try_success() {
+    ///         Ok(assert) => {
+    ///             assert.stdout(predicate::eq(b"Success\n" as &[u8]));
+    ///         }
+    ///         Err(err) => {
+    ///            err.assert().stdout(predicate::eq(b"Err but some specific output you might want to check\n" as &[u8]));
+    ///         }
+    ///     }
+    /// ```
+    pub fn assert(self) -> Assert {
+        self.assert
+    }
 }
 
 impl Error for AssertError {}


### PR DESCRIPTION
I'm in the process of writing integration tests with this awesome crate :) 

My tool is basically a CRUD cli for a distant API, and while writing tests I ran into this problem while testing deletions.
In some cases, i need to check the output of the `Assert` even if it succeeded when I expected a failure ( but that would work the other way around. 

An example : to verify a deletion process you'd do :delete, then read and expect an error : 
```rust
    Command::cargo_bin("myTool")
        .unwrap()
        .arg("delete")
        .arg("resource")
		.assert()
		.success();

    Command::cargo_bin("myTool")
        .unwrap()
        .arg("read")
        .arg("resource")
		.assert()
		.failure();
}
```

However in some cases the "read" operation succeed because the resource was not *yet* deleted by the remote system. 
I would need to check, because even if I was expecting a failure, a success might not invalidate the test. 
Continuing the above example : 

```rust
// first assert to delete the resource

// then read back: 

    let read = Command::cargo_bin("myTool")
        .unwrap()
        .arg("read")
        .arg("resource")
		.assert();

match read.try_failure() {
        Ok(assert) => {
				// here we are good but may want to verify a couple of things from the output
            	let output: &assert.get_output().stdout;
        }
        Err(err) => {
            let output: myType = serde_json::from_slice(&err.0.get_output().stdout).unwrap();
            // we check if it was marked for deletion. If so, it's all good.
            assert!(output.metadata.deletion_timestamp.is_some());
        }
    }
```

I was not sure if a getter method or simply marking the field public was the better choice there.. Let me know what you think.