### PR TITLE
fix: tty test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "concolor 0.0.11",
  "doc-comment",
  "escargot",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ concolor = { version = "0.0.11", optional = true }
 
 [dev-dependencies]
 escargot = "0.5"
+libc = "0.2"

--- a/examples/example_tty.rs
+++ b/examples/example_tty.rs
@@ -1,0 +1,21 @@
+use std::{
+    env,
+    io::{self, Read},
+};
+
+fn main() {
+    if isatty() {
+        let args: Vec<String> = env::args().collect();
+        for arg in args[1..].iter() {
+            println!("{}", arg);
+        }
+    } else {
+        let mut buf = String::new();
+        io::stdin().read_to_string(&mut buf).unwrap();
+        println!("{}", buf);
+    }
+}
+
+fn isatty() -> bool {
+    unsafe { libc::isatty(libc::STDIN_FILENO) != 0 }
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -497,7 +497,9 @@ impl Command {
 
     fn spawn(&mut self) -> io::Result<process::Child> {
         // stdout/stderr should only be piped for `output` according to `process::Command::new`.
-        self.cmd.stdin(process::Stdio::piped());
+        if self.stdin.is_some() {
+            self.cmd.stdin(process::Stdio::piped());
+        }
         self.cmd.stdout(process::Stdio::piped());
         self.cmd.stderr(process::Stdio::piped());
 

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -154,3 +154,23 @@ fn stderr_example() {
         .assert()
         .stderr("world\n");
 }
+
+#[test]
+fn pipe_example() {
+    assert_cmd::Command::cargo_bin("examples/example_tty")
+        .unwrap()
+        .write_stdin("stdin")
+        .assert()
+        .success()
+        .stdout("stdin\n");
+}
+
+#[test]
+fn tty_example() {
+    assert_cmd::Command::cargo_bin("examples/example_tty")
+        .unwrap()
+        .arg("arg")
+        .assert()
+        .success()
+        .stdout("arg\n");
+}


### PR DESCRIPTION
When I test a program that uses `isatty`, assert_cmd detects that it is not a tty even if it is a tty.
It is caused by passing pipe to stdin even when `write_stdin` is not used.
Fixed to pass pipe to stdin only when use `write_stdin`.
