### PR TITLE
fix: Make message format consistent

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1068,7 +1068,7 @@ impl fmt::Display for AssertError {
         match &self.reason {
             AssertReason::UnexpectedFailure { actual_code } => writeln!(
                 f,
-                "Unexpected failure.\ncode-{}\nstderr=```{}```",
+                "Unexpected failure.\ncode={}\nstderr=```{}```",
                 actual_code
                     .map(|actual_code| actual_code.to_string())
                     .unwrap_or_else(|| "<interrupted>".to_owned()),


### PR DESCRIPTION
It was probably just a finger slip.

I don't think it makes sense for it to be a dash and it's inconsistent with what is done in
https://github.com/assert-rs/assert_cmd/blob/ebf8e3e2f689fa1337e63637bc0d252da55fdf87/src/output.rs#L289