### PR TITLE
feat: implement `From<assert:cmd::Command>` for `process::Command`

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -508,6 +508,12 @@ impl From<process::Command> for Command {
     }
 }
 
+impl From<Command> for process::Command {
+    fn from(cmd: Command) -> process::Command {
+        cmd.cmd
+    }
+}
+
 impl<'c> OutputOkExt for &'c mut Command {
     fn ok(self) -> OutputResult {
         let output = self.output().map_err(OutputError::with_cause)?;


### PR DESCRIPTION
Allows conversion with `process::Command::from(asserted_cmd)`

As mentioned in #212 I was having trouble serializing the value of the inner `std::process::Command`. 

After this PR the following should be possible:
```rs
let cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))
let std_cmd = process::Command::from(cmd)
```