### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Specifically, we would encourage
 - File renames be isolated into their own commit
 - Add tests in a commit before their feature or fix, showing the current behavior.
   The diff for the feature/fix commit will then show how the behavior changed,
-  making it clearer to reviewrs and the community and showing people that the
+  making it clearer to reviewers and the community and showing people that the
   test is verifying the expected state.
   - e.g. [clap#5520](https://github.com/clap-rs/clap/pull/5520)
 


### PR DESCRIPTION
### Description:
This pull request fixes a typo in the CONTRIBUTING.md file: the word "revievrs" has been corrected to "reviewers."

### Reason for Change:
This change improves the readability of the documentation and eliminates potential confusion for community contributors. Clear and accurate documentation is essential as it serves as the main reference for new contributors and helps establish consistent collaboration standards.

### Checklist:
- [x] Fixed a typographical error.
- [x] Verified the file passes syntax checks.
- [x] Ensured the change does not affect functionality.
