### PR TITLE
chore:fix cargo clippy warning

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -61,7 +61,7 @@ impl OutputAssertExt for &mut process::Command {
         let output = match self.output() {
             Ok(output) => output,
             Err(err) => {
-                panic!("Failed to spawn {:?}: {}", self, err);
+                panic!("Failed to spawn {self:?}: {err}");
             }
         };
         Assert::new(output).append_context("command", format!("{self:?}"))


### PR DESCRIPTION

Running cargo clippy reports the following error.

```shell
warning: variables can be used directly in the `format!` string
  --> src/assert.rs:64:17
   |
64 |                 panic!("Failed to spawn {:?}: {}", self, err);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: requested on the command line with `-W clippy::uninlined-format-args`
help: change this to
   |
64 -                 panic!("Failed to spawn {:?}: {}", self, err);
64 +                 panic!("Failed to spawn {self:?}: {err}");
   |

warning: `assert_cmd` (lib) generated 1 warning (run `cargo clippy --fix --lib -p assert_cmd` to apply 1 suggestion)
```

This commit resolves the issue.
