### PR TITLE
feat(cargo): Add `cargo_bin!`

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -60,6 +60,9 @@ use std::fmt;
 use std::path;
 use std::process;
 
+#[doc(inline)]
+pub use crate::cargo_bin;
+
 /// Create a [`Command`] for a `bin` in the Cargo project.
 ///
 /// `CommandCargoExt` is an extension trait for [`Command`][std::process::Command] to easily launch a crate's
@@ -94,6 +97,8 @@ where
     /// binaries that can't be launched directly, such as cross-compiled binaries. When using
     /// this method with [cross](https://github.com/cross-rs/cross), no extra configuration is
     /// needed.
+    ///
+    /// **NOTE:** Prefer [`cargo_bin!`] as this makes assumptions about cargo
     ///
     /// # Examples
     ///
@@ -217,6 +222,8 @@ fn target_dir() -> path::PathBuf {
 }
 
 /// Look up the path to a cargo-built binary within an integration test.
+///
+/// **NOTE:** Prefer [`cargo_bin!`] as this makes assumptions about cargo
 pub fn cargo_bin<S: AsRef<str>>(name: S) -> path::PathBuf {
     cargo_bin_str(name.as_ref())
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -37,6 +37,8 @@ impl Command {
     ///
     /// See the [`cargo` module documentation][crate::cargo] for caveats and workarounds.
     ///
+    /// **NOTE:** Prefer [`cargo_bin!`][crate::cargo::cargo_bin!] as this makes assumptions about cargo
+    ///
     /// # Examples
     ///
     /// ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,31 +104,7 @@
 #![warn(clippy::print_stderr)]
 #![warn(clippy::print_stdout)]
 
-/// Allows you to pull the name from your Cargo.toml at compile time.
-///
-/// # Examples
-///
-/// ```should_panic
-/// use assert_cmd::Command;
-///
-/// let mut cmd = Command::cargo_bin(assert_cmd::crate_name!()).unwrap();
-/// let assert = cmd
-///     .arg("-A")
-///     .env("stdout", "hello")
-///     .env("exit", "42")
-///     .write_stdin("42")
-///     .assert();
-/// assert
-///     .failure()
-///     .code(42)
-///     .stdout("hello\n");
-/// ```
-#[macro_export]
-macro_rules! crate_name {
-    () => {
-        env!("CARGO_PKG_NAME")
-    };
-}
+mod macros;
 
 pub mod assert;
 pub mod cargo;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,25 @@
+/// Allows you to pull the name from your Cargo.toml at compile time.
+///
+/// # Examples
+///
+/// ```should_panic
+/// use assert_cmd::Command;
+///
+/// let mut cmd = Command::cargo_bin(assert_cmd::crate_name!()).unwrap();
+/// let assert = cmd
+///     .arg("-A")
+///     .env("stdout", "hello")
+///     .env("exit", "42")
+///     .write_stdin("42")
+///     .assert();
+/// assert
+///     .failure()
+///     .code(42)
+///     .stdout("hello\n");
+/// ```
+#[macro_export]
+macro_rules! crate_name {
+    () => {
+        env!("CARGO_PKG_NAME")
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,3 +23,28 @@ macro_rules! crate_name {
         env!("CARGO_PKG_NAME")
     };
 }
+
+/// The absolute path to a binary target's executable.
+///
+/// The `bin_target_name` is the name of the binary
+/// target, exactly as-is.
+///
+/// **NOTE:** This is only set when building an integration test or benchmark.
+///
+/// ## Example
+///
+/// ```rust,no_run
+/// #[test]
+/// fn cli_tests() {
+///     trycmd::TestCases::new()
+///         .default_bin_path(trycmd::cargo_bin!("bin-fixture"))
+///         .case("tests/cmd/*.trycmd");
+/// }
+/// ```
+#[macro_export]
+#[doc(hidden)]
+macro_rules! cargo_bin {
+    ($bin_target_name:expr) => {
+        ::std::path::Path::new(env!(concat!("CARGO_BIN_EXE_", $bin_target_name)))
+    };
+}


### PR DESCRIPTION
This is prep for rust-lang/cargo#14125 which may break `fn cargo_bin`