### PR TITLE
Update example to use cargo_bin_cmd macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Here's a trivial example:
 
-```rust,no_run
+```rust,no_run,ignore
 use assert_cmd::cargo::cargo_bin_cmd;
 
 let mut cmd = cargo_bin_cmd!("bin_fixture").unwrap();


### PR DESCRIPTION
Update README.md to fit #248 `cargo_bin` deprecation.